### PR TITLE
refactor(db): move mongodb uri to config file

### DIFF
--- a/src/client/lib/config.ts
+++ b/src/client/lib/config.ts
@@ -1,0 +1,1 @@
+export const BACK_URI = process.env.NEXT_PUBLIC_BACKEND_URI;

--- a/src/client/provider/ApolloWrapper.tsx
+++ b/src/client/provider/ApolloWrapper.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { ApolloClient, ApolloProvider, InMemoryCache} from '@apollo/client';
-import { BACK_URI } from "@/lib/config";
+import { BACK_URI } from '../lib/config';
 
 const client = new ApolloClient({
     uri: `${BACK_URI}/graphql`,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,0 @@
-export const JWT_SECRET = process.env.JWT_SECRET || 'secret-key';
-export const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '1d';
-export const MONGODB_URI = process.env.MONGODB_URI as string;
-export const BACK_URI = process.env.NEXT_PUBLIC_BACKEND_URI as string;

--- a/src/server/db/dbConnect.ts
+++ b/src/server/db/dbConnect.ts
@@ -1,23 +1,21 @@
 import mongoose from 'mongoose';
-import { MONGODB_URI } from '@/lib/config';
 
-if (!MONGODB_URI) {
-  throw new Error('Please define the MONGODB_URI environment variable');
-}
-
-// Objeto de caché local al módulo
 const cached = {
   conn: null as typeof mongoose | null,
   promise: null as Promise<typeof mongoose> | null
 };
 
 async function dbConnect(): Promise<typeof mongoose> {
-  if (cached.conn) {
-    return cached.conn;
+  const uri = process.env.MONGODB_URI;
+
+  if (!uri) {
+    throw new Error('Please define the MONGODB_URI environment variable');
   }
 
+  if (cached.conn) return cached.conn;
+
   if (!cached.promise) {
-    cached.promise = mongoose.connect(MONGODB_URI);
+    cached.promise = mongoose.connect(uri);
   }
 
   try {

--- a/src/server/db/dbConnect.ts
+++ b/src/server/db/dbConnect.ts
@@ -1,6 +1,5 @@
 import mongoose from 'mongoose';
-
-const MONGODB_URI = process.env.MONGODB_URI as string;
+import { MONGODB_URI } from '@/lib/config';
 
 if (!MONGODB_URI) {
   throw new Error('Please define the MONGODB_URI environment variable');

--- a/src/server/graphql/core/context.ts
+++ b/src/server/graphql/core/context.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import jwt from 'jsonwebtoken';
 import { User } from '../models/User';
-import { JWT_SECRET } from '@/lib/config';
+import { JWT_SECRET } from '@/server/lib/config';
 
 export async function createContext({ req }: { req: NextRequest }) {
   const token = req.headers.get('authorization')?.replace('Bearer ', '');

--- a/src/server/graphql/modules/auth/service.ts
+++ b/src/server/graphql/modules/auth/service.ts
@@ -1,6 +1,6 @@
 import jwt from "jsonwebtoken";
 import { User } from "../../models/User";
-import { JWT_SECRET } from "@/lib/config";
+import { JWT_SECRET } from "@/server/lib/config";
 import dbConnect from "@/server/db/dbConnect";
 
 export class AuthService{

--- a/src/server/lib/config.ts
+++ b/src/server/lib/config.ts
@@ -1,0 +1,1 @@
+export const JWT_SECRET = process.env.JWT_SECRET || 'secret';


### PR DESCRIPTION
Centralize configuration by moving the MONGODB_URI constant to the shared config module. This improves maintainability and follows the DRY principle.