### PR TITLE
style(Header): fix dark mode color classes inconsistency

### DIFF
--- a/src/client/components/shared/Header/Header.tsx
+++ b/src/client/components/shared/Header/Header.tsx
@@ -103,7 +103,7 @@ export const Header = () => {
               transition-all duration-300
         ${
           scrolled
-            ? "bg-neutral-4 dark:bg-neutral-2 text-neutral-1 dark:text-neutral-5 hover:bg-neutral-3 dark:hover:bg-neutral-1"
+            ? "bg-neutral-2 dark:bg-neutral-4 text-neutral-5 dark:text-neutral-1 hover:bg-neutral-1 dark:hover:bg-neutral-3"
             : "bg-neutral-2 dark:bg-neutral-4 text-neutral-5 dark:text-neutral-1 hover:bg-neutral-1 dark:hover:bg-neutral-3"
         }
               text-[12px] 


### PR DESCRIPTION
The dark mode color classes were inconsistent when the header is scrolled vs not scrolled. Aligned the color classes to maintain consistent styling in both states.